### PR TITLE
ci: use github actions macos

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,39 +33,20 @@ pipeline {
       }
     }
     stage('Test') {
-      failFast false
-      matrix {
-        options { skipDefaultCheckout() }
-        axes {
-          axis {
-            name 'GO_VERSION'
-            values '1.15.6'
-          }
-          axis {
-            name 'PLATFORM'
-            values 'ubuntu-18 && immutable', 'macosx && x86_64'
+      steps {
+        withGithubNotify(context: "Test") {
+          deleteDir()
+          unstash 'source'
+          withGoEnv(version: "${GO_VERSION}"){
+            dir("${BASE_DIR}"){
+              cmd(label: "check for ${GO_VERSION}", script: 'GOTESTSUM_JUNITFILE=junit.xml make check')
+            }
           }
         }
-        stages {
-          stage('Test') {
-            agent { label "${PLATFORM}" }
-            steps {
-              withGithubNotify(context: "Test-${GO_VERSION}-${PLATFORM}") {
-                deleteDir()
-                unstash 'source'
-                withGoEnv(version: "${GO_VERSION}"){
-                  dir("${BASE_DIR}"){
-                    cmd(label: "check for ${GO_VERSION} in ${PLATFORM}", script: 'GOTESTSUM_JUNITFILE=junit.xml make check')
-                  }
-                }
-              }
-            }
-            post {
-              always {
-                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
-              }
-            }
-          }
+      }
+      post {
+        always {
+          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
         }
       }
     }

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
 
+jobs:
   macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,22 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '>=1.15.6'
+
+    - name: Run test
+      run: go test -v ./...


### PR DESCRIPTION
We are in the transition to use ephemeral workers, but until then there is a requirement to decommission the existing MacOS workers. For such this proposal uses GitHub actions for MacOS until we can use the ephemeral workers.