### PR TITLE
Remove TestServerHTTPRequestTimeout which hangs

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -28,7 +28,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,17 +78,6 @@ func TestServerHTTPRequestTLS(t *testing.T) {
 	resp.Body.Close()
 
 	assert.NotNil(t, rTLS)
-}
-
-func TestServerHTTPRequestTimeout(t *testing.T) {
-	srv, _ := startConfiguredServer(t, nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	}))
-
-	client := srv.Client()
-	client.Timeout = 100 * time.Millisecond
-	_, err := client.Get(srv.URL)
-	assert.Error(t, err)
 }
 
 func TestServerGRPCListener(t *testing.T) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -90,10 +90,6 @@ func TestServerHTTPRequestTimeout(t *testing.T) {
 	client.Timeout = 100 * time.Millisecond
 	_, err := client.Get(srv.URL)
 	assert.Error(t, err)
-
-	client.CloseIdleConnections()
-	err = srv.Config.Shutdown(context.Background())
-	assert.NoError(t, err)
 }
 
 func TestServerGRPCListener(t *testing.T) {


### PR DESCRIPTION
Removing `TestServerHTTPRequestTimeout` as it hangs on CI as well as on my machine because of a race condition in the test.

In the code
```go
func TestServerHTTPRequestTimeout(t *testing.T) {
	srv, _ := startConfiguredServer(t, nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		<-r.Context().Done()
	}))

	client := srv.Client()
	client.Timeout = 100 * time.Millisecond
	_, err := client.Get(srv.URL)
	assert.Error(t, err)

	client.CloseIdleConnections()
	err = srv.Config.Shutdown(context.Background())
	assert.NoError(t, err)
}
```

`client.CloseIdleConnections()` may or may not close the connection depending on whether the connection is considered idle. On a faster machine, by the time this function is called, the connection may not be idle yet. This may leave the connection open even after the function call. Given that `srv.Config.Shutdown` waits for all the connection to close, it will wait indefinitely and cause CI to timeout.

Closes #11 