### PR TITLE
upgrade go version to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/gmux
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
# Overview
This PR updates the go version to 1.24.13

Assisted by Claude 4.6 Opus (Thinking)

Made with [Cursor](https://cursor.com)